### PR TITLE
expand to fullscreen on Show PM action

### DIFF
--- a/src/amp_client.js
+++ b/src/amp_client.js
@@ -1,16 +1,9 @@
 function AMPClient (config, onAMPMessage) {
   this._config = config;
   this._onAMPMessage = onAMPMessage;
-  this._config.fullscreen = config.clientConfig &&
-    config.clientConfig.fullscreen === false ?
-      false :
-      true;
 }
 AMPClient.prototype.userTriggered = function () {
   return this._config.promptTrigger === 'action';
-};
-AMPClient.prototype.isFullScreen = function () {
-  return this._config.fullscreen;
 };
 AMPClient.prototype._postMessage = function (type, action, info) {
   console.info('postMessage: '+type+', '+action+' '+ (info ? JSON.stringify(info) : ''));
@@ -42,17 +35,11 @@ AMPClient.prototype.dismiss = function () {
 AMPClient.prototype._ready = function () {
   this._ui('ready');
 };
-AMPClient.prototype._fullscreen = function () {
-  var self = this;
-  setTimeout(function () {
-    self._ui('enter-fullscreen');
-  }, 200);
+AMPClient.prototype.fullscreen = function () {
+  this._ui('enter-fullscreen');
 };
 AMPClient.prototype.show = function () {
   this._ready();
-  if(this.isFullScreen()){
-    this._fullscreen();
-  }
 };
 
 export default AMPClient;

--- a/src/amp_client.test.js
+++ b/src/amp_client.test.js
@@ -29,24 +29,6 @@ describe('AMPClient', () => {
         amp.show()
         expect(onAMPMessage).toHaveBeenCalledWith({ type: 'consent-ui', action: 'ready' })
       })
-
-      it('calls onAMPMessage with \'enter-fullscreen\' in 200 ms', () => {
-        const amp = new AMPClient({}, onAMPMessage)
-        amp.show()
-        jest.advanceTimersByTime(199)
-        expect(onAMPMessage).not.toHaveBeenCalledWith({ type: 'consent-ui', action: 'enter-fullscreen' })
-        jest.advanceTimersByTime(1)
-        expect(onAMPMessage).toHaveBeenCalledWith({ type: 'consent-ui', action: 'enter-fullscreen' })
-      })
-
-      describe('when config.clientConfig.fullscreen is false', () => {
-        it('does not call onAMPMessage with \'enter-fullscreen\'', () => {
-          const amp = new AMPClient({ clientConfig: { fullscreen: false }}, onAMPMessage)
-          amp.show()
-          jest.runAllTimers()
-          expect(onAMPMessage).not.toHaveBeenCalledWith({ type: 'consent-ui', action: 'enter-fullscreen' })
-        })
-      })
     })
   })
 

--- a/src/sourcepoint_client.js
+++ b/src/sourcepoint_client.js
@@ -6,8 +6,9 @@ var loggedFunction = function(name, callback) {
 };
 
 var ACCEPT_ALL_CHOICE_TYPE = 11;
-var ACCEPT_ALL = "all"
-var REJECT_ALL = "none"
+var SHOW_PM_CHOICE_TYPE = 12;
+var ACCEPT_ALL = "all";
+var REJECT_ALL = "none";
 
 export default function (amp) {
   return {
@@ -23,7 +24,16 @@ export default function (amp) {
       }
     }),
     onMessageChoiceSelect: loggedFunction('onMessageChoiceSelect', function (_choiceId, choiceType) {
-      amp.purposeConsent = choiceType === ACCEPT_ALL_CHOICE_TYPE ? ACCEPT_ALL : REJECT_ALL
+      switch(choiceType) {
+        case SHOW_PM_CHOICE_TYPE:
+          amp.fullscreen();
+          break;
+        case ACCEPT_ALL_CHOICE_TYPE:
+          amp.purposeConsent = ACCEPT_ALL;
+          break;
+        default:
+          amp.purposeConsent = REJECT_ALL
+      }
     }),
     onPrivacyManagerAction: loggedFunction('onPrivacyManagerAction', function (consents) {
       // consents: {"purposeConsent":"all|some|none", "vendorConsent":"all|some|none" }

--- a/src/sourcepoint_client.test.js
+++ b/src/sourcepoint_client.test.js
@@ -1,17 +1,17 @@
 import SourcePointClient from './sourcepoint_client'
+import AMPClient from './amp_client'
 
 let ampClient = {}
 let sourcepoint = {}
 
+const prototypeDoubleOf = (obj) => Object
+  .getOwnPropertyNames(obj.prototype)
+  .filter(prop => typeof obj.prototype[prop] === 'function')
+  .reduce((allProps, prop) => ({ ...allProps, [prop]: jest.fn() }), {})
+
 describe('SourcePointClient', () => {
   beforeEach(() => {
-    ampClient = {
-      show: jest.fn(),
-      dismiss: jest.fn(),
-      userTriggered: jest.fn(),
-      accept: jest.fn(),
-      reject: jest.fn()
-    }
+    ampClient = prototypeDoubleOf(AMPClient)
     sourcepoint = SourcePointClient(ampClient)
   })
 
@@ -48,14 +48,21 @@ describe('SourcePointClient', () => {
   })
 
   describe('onMessageChoiceSelect', () => {
-    describe('when called with choiceType equals to 11', () => {
+    describe('when called with choiceType equals to 11 (accept all)', () => {
       it('sets ampClient.purposeConsent to "all"', () => {
         sourcepoint.onMessageChoiceSelect(null, 11)
         expect(ampClient.purposeConsent).toBe("all")
       })
     })
 
-    describe('when called with choiceType is different than 11', () => {
+    describe('when called with choiceType equals to 12 (show PM)', () => {
+      it('calls ampClient.fullscreen', () => {
+        sourcepoint.onMessageChoiceSelect(null, 12)
+        expect(ampClient.fullscreen).toHaveBeenCalled()
+      })
+    })
+
+    describe('when called with choiceType is different than 11 and 15', () => {
       it('sets ampClient.purposeConsent to "none"', () => {
         sourcepoint.onMessageChoiceSelect(null, null)
         expect(ampClient.purposeConsent).toBe("none")


### PR DESCRIPTION
[AMP decided it's not cool to show a 1st layer message fullscreen](https://github.com/ampproject/amphtml/issues/26197) but rather wait for user interaction. That means our messages are all displaying in a small (30vh by default) bottom space including the PM (which is not great).

In this PR we trigger AMP to expand the ui to fullscreen when the user clicks on "Show Privacy Manager" (aka show pm action = 12).

---

Related to https://sourcepoint.atlassian.net/browse/SP-3009