### PR TITLE
set initialHeight of ui to 60vh

### DIFF
--- a/src/amp_client.js
+++ b/src/amp_client.js
@@ -9,7 +9,8 @@ AMPClient.prototype._postMessage = function (type, action, info) {
   console.info('postMessage: '+type+', '+action+' '+ (info ? JSON.stringify(info) : ''));
   var payload = {
     type: type,
-    action: action
+    action: action,
+    initialHeight: '60vh'
   };
   if(info !== undefined) payload.info = info;
   this._onAMPMessage(payload);

--- a/src/amp_client.test.js
+++ b/src/amp_client.test.js
@@ -2,6 +2,7 @@ import AMPClient from './amp_client'
 
 jest.useFakeTimers()
 let onAMPMessage
+const defaultPayload = { initialHeight: '60vh' }
 
 describe('AMPClient', () => {
   beforeEach(() => { onAMPMessage = jest.fn() });
@@ -27,7 +28,11 @@ describe('AMPClient', () => {
       it('calls onAMPMessage with \'ready\' imediately', () => {
         const amp = new AMPClient({}, onAMPMessage)
         amp.show()
-        expect(onAMPMessage).toHaveBeenCalledWith({ type: 'consent-ui', action: 'ready' })
+        expect(onAMPMessage).toHaveBeenCalledWith({
+          ...defaultPayload,
+          type: 'consent-ui',
+          action: 'ready'
+        })
       })
     })
   })
@@ -41,6 +46,7 @@ describe('AMPClient', () => {
           amp[action](consentString)
           jest.runAllTimers()
           expect(onAMPMessage).toHaveBeenCalledWith({
+            ...defaultPayload,
             type: 'consent-response',
             action,
             info: consentString
@@ -54,7 +60,11 @@ describe('AMPClient', () => {
         const amp = new AMPClient({}, onAMPMessage)
         amp.dismiss()
         jest.runAllTimers()
-        expect(onAMPMessage).toHaveBeenCalledWith({ type: 'consent-response', action: 'dismiss' })
+        expect(onAMPMessage).toHaveBeenCalledWith({
+          ...defaultPayload,
+          type: 'consent-response',
+          action: 'dismiss'
+        })
       })
     })
   })


### PR DESCRIPTION
The AMP team has restricted the consent ui from showing fullscreen. By default, the consent ui takes 30% of the viewport (`30vh`) but we're allowed to set it with anything from `10vh` to `60vh`. 

This PR sets the initial height of the consent ui to `60vh`.